### PR TITLE
Performance enhancement

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -426,17 +426,14 @@ impl<'a> Builder<'a> {
 
     /// Executes the PostgREST request.
     pub async fn execute(mut self) -> Result<Response, Error> {
-        match self.schema {
-            Some(schema) => {
-                let key = match self.method {
-                    Method::GET | Method::HEAD => "Accept-Profile",
-                    _ => "Content-Profile",
-                };
-                self.headers
-                    .insert(key, HeaderValue::from_str(&schema).unwrap());
-            }
-            None => {}
-        };
+        if let Some(schema) = self.schema {
+            let key = match self.method {
+                Method::GET | Method::HEAD => "Accept-Profile",
+                _ => "Content-Profile",
+            };
+            self.headers
+                .insert(key, HeaderValue::from_str(&schema).unwrap());
+        }
         match self.method {
             Method::GET | Method::HEAD => {}
             _ => {
@@ -448,7 +445,7 @@ impl<'a> Builder<'a> {
             .request(self.method, self.url)
             .headers(self.headers)
             .query(&self.queries)
-            .body(self.body.unwrap_or("".to_string()))
+            .body(self.body.unwrap_or_default())
             .send()
             .await
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -10,7 +10,7 @@ fn clean_param(param: &str) -> Cow<str> {
     }
 }
 
-impl Builder {
+impl Builder<'_> {
     /// Finds all rows which doesn't satisfy the filter.
     ///
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,11 +79,13 @@ mod filter;
 
 pub use builder::Builder;
 use reqwest::header::{HeaderMap, HeaderValue, IntoHeaderName};
+use reqwest::Client;
 
 pub struct Postgrest {
     url: String,
     schema: Option<String>,
     headers: HeaderMap,
+    client: Client,
 }
 
 impl Postgrest {
@@ -104,6 +106,7 @@ impl Postgrest {
             url: url.into(),
             schema: None,
             headers: HeaderMap::new(),
+            client: Client::new(),
         }
     }
 
@@ -129,7 +132,7 @@ impl Postgrest {
         self
     }
 
-    /// Add arbitrary headers to the request.  For instance when you may want to connect
+    /// Add arbitrary headers to the request. For instance when you may want to connect
     /// through an API gateway that needs an API key header.
     ///
     /// # Example
@@ -168,7 +171,7 @@ impl Postgrest {
         T: AsRef<str>,
     {
         let url = format!("{}/{}", self.url, table.as_ref());
-        Builder::new(url, self.schema.clone(), self.headers.clone())
+        Builder::new(url, self.schema.clone(), self.headers.clone(), &self.client)
     }
 
     /// Perform a stored procedure call.
@@ -187,7 +190,7 @@ impl Postgrest {
         U: Into<String>,
     {
         let url = format!("{}/rpc/{}", self.url, function.as_ref());
-        Builder::new(url, self.schema.clone(), self.headers.clone()).rpc(params)
+        Builder::new(url, self.schema.clone(), self.headers.clone(), &self.client).rpc(params)
     }
 }
 


### PR DESCRIPTION
Hello @soedirgo amazing work with this crate. It is quite useful with rust and postgrest. While digging into it, I noticed a possible improvement which could impact the performance of the crate.

As of now, the crate creates a new http `reqwest::Client` on the execution of each query, and this behavior is not the best, performance wise. Instead, a single client should be created, which lives on the `Postgrest` struct itself and can be borrowed by the `Builder` struct for executing a query. I am suggesting this behaviour as the reqwest docs recommend the reuse of `reqwest::Client` as there is a pool of connections managed by the client itself. To quote the docs `The Client holds a connection pool internally, so it is advised that you create one and reuse it.`

I have also refactored the `Builder::execute` fn into idiomatic and more readable rust code.

I hope this PR proves to be helpful, I have ran the tests and all of them are passing. Please have a look yourself and I would be glad if you think my contributions are valid. Also let me know if there is something that you would like me to change in my PR.