### PR TITLE
foreign table limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 
 [dev-dependencies]
 json = "0.12"
-tokio = { version = "1.5", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -567,6 +567,19 @@ mod tests {
     }
 
     #[test]
+    fn foreign_table_limit_assert_query() {
+        let client = Client::new();
+        let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), &client)
+            .foreign_table_limit(20, "some_table");
+        assert_eq!(
+            builder
+                .queries
+                .contains(&("some_table.limit".to_string(), "20".to_string())),
+            true
+        );
+    }
+
+    #[test]
     fn range_assert_range_header() {
         let client = Client::new();
         let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), &client).range(10, 20);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -201,6 +201,27 @@ impl<'a> Builder<'a> {
         );
         self
     }
+    
+    /// Limits the result of a foreign table with the specified `count`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use postgrest::Postgrest;
+    ///
+    /// let client = Postgrest::new("https://your.postgrest.endpoint");
+    /// client
+    ///     .from("countries")
+    ///     .select("name, cities(name)")
+    ///     .foreign_table_limit(1, "cities");
+    /// ```
+    pub fn foreign_table_limit<T>(mut self, count: usize, foreign_table: T) -> Self
+    where
+        T: Into<String>,
+        {
+            self.queries.push((format!("{}.limit", foreign_table.into()), count.to_string()));
+        self
+    }
 
     /// Limits the result to rows within the specified range, inclusive.
     ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -201,7 +201,7 @@ impl<'a> Builder<'a> {
         );
         self
     }
-    
+
     /// Limits the result of a foreign table with the specified `count`.
     ///
     /// # Example
@@ -218,8 +218,9 @@ impl<'a> Builder<'a> {
     pub fn foreign_table_limit<T>(mut self, count: usize, foreign_table: T) -> Self
     where
         T: Into<String>,
-        {
-            self.queries.push((format!("{}.limit", foreign_table.into()), count.to_string()));
+    {
+        self.queries
+            .push((format!("{}.limit", foreign_table.into()), count.to_string()));
         self
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

It adds the ability to limit foreign table queries.

## What is the current behavior?

Currently, there is no ability to limit foreign table queries.

## What is the new behavior?

.foreign_table_limit(count, table_name) allows you to limit the response on queries of foreign tables.

## Additional context

![Screenshot 2023-01-11 at 19 33 52](https://user-images.githubusercontent.com/38776747/211962241-f1564bf4-2b97-4161-8fec-934d0b04fdd2.png)

https://supabase.com/docs/reference/javascript/limit
