### PR TITLE
Spencer/add foreign table order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "Apache-2.0 OR MIT"
 keywords = ["postgres", "postgrest", "rest", "api"]
 categories = ["development-tools"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -629,8 +629,12 @@ mod tests {
     #[test]
     fn order_with_options_assert_query() {
         let client = Client::new();
-        let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), &client)
-            .order_with_options("name", Some("cities"), true, false);
+        let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), &client).order_with_options(
+            "name",
+            Some("cities"),
+            true,
+            false,
+        );
         assert_eq!(
             builder
                 .queries

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -179,6 +179,29 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Orders the result of a foreign table with the specified `columns`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use postgrest::Postgrest;
+    ///
+    /// let client = Postgrest::new("https://your.postgrest.endpoint");
+    /// client
+    ///     .from("countries")
+    ///     .select("name, cities(name)")
+    ///     .foreign_table_order("name.desc", "cities");
+    /// ```
+    pub fn foreign_table_order<T, U>(mut self, columns: T, foreign_table: U) -> Self
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        self.queries
+            .push((format!("{}.order", foreign_table.into()), columns.into()));
+        self
+    }
+
     /// Limits the result with the specified `count`.
     ///
     /// # Example
@@ -553,6 +576,19 @@ mod tests {
             builder
                 .queries
                 .contains(&("order".to_string(), "id".to_string())),
+            true
+        );
+    }
+
+    #[test]
+    fn foreign_table_order_assert_query() {
+        let client = Client::new();
+        let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), &client)
+            .foreign_table_order("name", "cities");
+        assert_eq!(
+            builder
+                .queries
+                .contains(&("cities.order".to_string(), "name".to_string())),
             true
         );
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -190,12 +190,12 @@ impl<'a> Builder<'a> {
     /// client
     ///     .from("countries")
     ///     .select("name, cities(name)")
-    ///     .order_with_options("name", "cities", true, false);
+    ///     .order_with_options("name", Some("cities"), true, false);
     /// ```
     pub fn order_with_options<T, U>(
         mut self,
         columns: T,
-        foreign_table: U,
+        foreign_table: Option<U>,
         ascending: bool,
         nulls_first: bool,
     ) -> Self
@@ -204,9 +204,11 @@ impl<'a> Builder<'a> {
         U: Into<String>,
     {
         let mut key = "order".to_string();
-        let foreign_table = foreign_table.into();
-        if !foreign_table.is_empty() {
-            key = format!("{}.order", foreign_table);
+        if let Some(foreign_table) = foreign_table {
+            let foreign_table = foreign_table.into();
+            if !foreign_table.is_empty() {
+                key = format!("{}.order", foreign_table);
+            }
         }
 
         let mut ascending_string = "desc";
@@ -628,7 +630,7 @@ mod tests {
     fn order_with_options_assert_query() {
         let client = Client::new();
         let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), &client)
-            .order_with_options("name", "cities", true, false);
+            .order_with_options("name", Some("cities"), true, false);
         assert_eq!(
             builder
                 .queries

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ mod builder;
 mod filter;
 
 pub use builder::Builder;
+pub use builder::OrderOptions;
 use reqwest::header::{HeaderMap, HeaderValue, IntoHeaderName};
 use reqwest::Client;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,6 @@ mod builder;
 mod filter;
 
 pub use builder::Builder;
-pub use builder::OrderOptions;
 use reqwest::header::{HeaderMap, HeaderValue, IntoHeaderName};
 use reqwest::Client;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add the ability to order foreign tables.

## What is the current behavior?

There is no ability to order on foreign tables

## What is the new behavior?

client
     .from("countries")
     .select("name, cities(name)")
     .order_with_options("name", Some("cities"), true, false);

You also have the ability to specify the other two options such as ascending and nulls_first.

## Additional context

https://supabase.com/docs/reference/javascript/order
