### PR TITLE
refactor: Allow `Builder` to be cloned by removing unnecessary reference and lifetime.

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,6 @@
 use crate::Builder;
 
-impl Builder<'_> {
+impl Builder {
     /// Finds all rows which doesn't satisfy the filter.
     ///
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,12 @@ impl Postgrest {
         T: AsRef<str>,
     {
         let url = format!("{}/{}", self.url, table.as_ref());
-        Builder::new(url, self.schema.clone(), self.headers.clone(), &self.client)
+        Builder::new(
+            url,
+            self.schema.clone(),
+            self.headers.clone(),
+            self.client.clone(),
+        )
     }
 
     /// Perform a stored procedure call.
@@ -190,7 +195,13 @@ impl Postgrest {
         U: Into<String>,
     {
         let url = format!("{}/rpc/{}", self.url, function.as_ref());
-        Builder::new(url, self.schema.clone(), self.headers.clone(), &self.client).rpc(params)
+        Builder::new(
+            url,
+            self.schema.clone(),
+            self.headers.clone(),
+            self.client.clone(),
+        )
+        .rpc(params)
     }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

`request::Client` is already cloneable since it's just an `Arc<ClientRef>`. So let's get rid of all of the `&'a Client` stuff and instead just have Builder own a Client, and clone it when needed.

## What is the current behavior?

`Builder` has a `&'a Client`.

## What is the new behavior?

`Builder` owns its own `Client`, and therefore is able to be `#[derive(Clone)]`.

## Additional context

The impetus for this change is that I wanted to build support for automatically paginating `Builder`s in order to transparently fetch more rows than a single request is able to. Since executing a builder consumes it, I needed a way to keep the original builder around after executing, in order to update its `range` and make the request for the next page of results.

A much trimmed down example of what this could look like:
```rust
async fn api_exec<T>(b: postgrest::Builder) -> anyhow::Result<T>
where
    for<'de> T: serde::Deserialize<'de>,
{
    let req = b.execute().await?;
    let status = resp.status();

    if status.is_success() {
        let v: T = resp.json().await?;
        Ok(v)
    } else {
        let body = resp.text().await?;
        anyhow::bail!("{status}: {body}");
    }
}

async fn api_exec_paginated<T>(b: postgrest::Builder) -> anyhow::Result<Vec<T>>
where
    for<'de> T: serde::Deserialize<'de>,
{
    let mut offset = 0;
    let mut rows: Vec<T> = vec![];

    loop {
        let req = b.clone().range(offset, offset + API_ROW_LIMIT);
        let mut resp = api_exec::<Vec<T>>(req).await?;

        if resp.len() == 0 {
            break;
        }

        offset += resp.len();
        rows.append(&mut resp);
    }

    Ok(rows)
}
```

A side benefit here is that (at least IMO) this is more ergonomic: no more lifetimes cluttering any struct that needs to hold a `Builder`
