### PR TITLE
builder: select() shoudn't override `self.method`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -153,7 +153,6 @@ impl<'a> Builder<'a> {
     where
         T: Into<String>,
     {
-        self.method = Method::GET;
         self.queries.push(("select".to_string(), columns.into()));
         self
     }
@@ -547,8 +546,8 @@ impl<'a> Builder<'a> {
         self
     }
 
-    /// Executes the PostgREST request.
-    pub async fn execute(mut self) -> Result<Response, Error> {
+    /// Build the PostgREST request.
+    pub fn build(mut self) -> reqwest::RequestBuilder {
         if let Some(schema) = self.schema {
             let key = match self.method {
                 Method::GET | Method::HEAD => "Accept-Profile",
@@ -569,8 +568,11 @@ impl<'a> Builder<'a> {
             .headers(self.headers)
             .query(&self.queries)
             .body(self.body.unwrap_or_default())
-            .send()
-            .await
+    }
+
+    /// Executes the PostgREST request.
+    pub async fn execute(self) -> Result<Response, Error> {
+        self.build().send().await
     }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and a backwards-compatible feature improvement.

## What is the current behavior?

`select()` unexpectedly overwrites `self.method` with `Method::GET`.

## What is the new behavior?

`self.method` is left alone.

## Additional context

We also wanted a way to obtain but not execute a request in order to further tweak it and/or add logging of the pre-flight request. This PR moves all of the request building logic to `build()`, and then makes `execute()` a simple wrapper.