### PR TITLE
Make Postgrest Clone (Fixes #53)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub use builder::Builder;
 use reqwest::header::{HeaderMap, HeaderValue, IntoHeaderName};
 use reqwest::Client;
 
+#[derive(Clone)]
 pub struct Postgrest {
     url: String,
     schema: Option<String>,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement

## What is the new behavior?

`Postgrest` is now `Clone`
