### PR TITLE
chore: Upgrade `reqwest` to v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 edition = "2021"
 
 [dependencies]
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 json = "0.12"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. Updates a dependency's version.

## What is the current behavior?

N/A.

## What is the new behavior?

No behavioral change. See the [changelog](https://github.com/seanmonstar/reqwest/releases) for what's changed in `reqwest`.

## Additional context

Add any other context or screenshots.
