### PR TITLE
Fix supabase rest endpoint trailing /

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Simplified example using a custom header (e.g. for API gateway authentication wi
 ```rust
 use postgrest::Postgrest;
 
-let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
+let client = Postgrest::new("https://your.supabase.endpoint/rest/v1")
     .insert_header("apikey", "ExampleAPIKeyValue"); // EXAMPLE ONLY!
 // Don't actually hard code this value, that's really bad. Use environment
 // variables like with the dotenv(https://crates.io/crates/dotenv) crate to inject
@@ -76,7 +76,7 @@ use dotenv;
 
 dotenv::dotenv().ok(); 
 
-let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
+let client = Postgrest::new("https://your.supabase.endpoint/rest/v1")
     .insert_header(
         "apikey",
         dotenv::var("SUPABASE_PUBLIC_API_KEY").unwrap())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -26,9 +26,11 @@ impl Builder {
     where
         T: Into<String>,
     {
+        let url = url.into().trim_end_matches('/').to_string();
+
         let mut builder = Builder {
             method: Method::GET,
-            url: url.into(),
+            url,
             schema,
             queries: Vec::new(),
             headers,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Postgrest builder now removes trailing '/' from Supabase rest endpoint url. Updates readme to show trailing '/' is not required in builder.

## What is the current behavior?

Readme currently says endpoint should be 'https://your.supabase.endpoint/rest/v1/' however this results in requests being made to 'https://your.supabase.endpoint/rest/v1//[query]'. Since migration to v2, this is breaking.

## What is the new behavior?

Builder now strips trailing '/' to ensure 'https://your.supabase.endpoint/rest/v1/' and 'https://your.supabase.endpoint/rest/v1' work as valid endpoints. 
