### PR TITLE
feat(docs): improve documentation of pgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
     .insert_header(
         "apikey",
         dotenv::var("SUPABASE_PUBLIC_API_KEY").unwrap())
-    .insert_header("Authorization", format!("Bearer {}", SERVICE_KEY))
+    .insert_header("Authorization", format!("Bearer {}", SERVICE_KEY));
 
 let resp = client
     .from("your_table")

--- a/README.md
+++ b/README.md
@@ -74,12 +74,36 @@ let body = resp
 use postgrest::Postgrest;
 use dotenv;
 
-dotenv::dotenv().ok(); 
+dotenv::dotenv().ok();
 
 let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
     .insert_header(
         "apikey",
         dotenv::var("SUPABASE_PUBLIC_API_KEY").unwrap())
+let resp = client
+    .from("your_table")
+    .select("*")
+    .execute()
+    .await?;
+let body = resp
+    .text()
+    .await?;
+```
+
+if you have RLS enabled you're required to add an extra header for this libary to  function correctly.
+
+```rust
+use postgrest::Postgrest;
+use dotenv;
+
+dotenv::dotenv().ok();
+
+let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
+    .insert_header(
+        "apikey",
+        dotenv::var("SUPABASE_PUBLIC_API_KEY").unwrap())
+    .insert_header("Authorization", format!("Bearer {}", SERVICE_KEY))
+
 let resp = client
     .from("your_table")
     .select("*")


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix #55

## What is the current behavior?

When working with tables that have RLS policies enabled, examples on read me does work as expected.

## What is the new behavior?

This pr added an example to remind people to add service token authorization header when they have RLS policy enabled on their tables. 

## Additional context

Add any other context or screenshots.
