### PR TITLE
fix(docs): removes trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Simplified example using a custom header (e.g. for API gateway authentication wi
 ```rust
 use postgrest::Postgrest;
 
-let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
+let client = Postgrest::new("https://your.supabase.endpoint/rest/v1")
     .insert_header("apikey", "ExampleAPIKeyValue"); // EXAMPLE ONLY!
 // Don't actually hard code this value, that's really bad. Use environment
 // variables like with the dotenv(https://crates.io/crates/dotenv) crate to inject
@@ -76,7 +76,7 @@ use dotenv;
 
 dotenv::dotenv().ok(); 
 
-let client = Postgrest::new("https://your.supabase.endpoint/rest/v1/")
+let client = Postgrest::new("https://your.supabase.endpoint/rest/v1")
     .insert_header(
         "apikey",
         dotenv::var("SUPABASE_PUBLIC_API_KEY").unwrap())


### PR DESCRIPTION
This can cause issues with pathing...

## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

Currently if you follow the docs to a T, which gives the supabase URL a trailing slash, it breaks paths.

## What is the new behavior?

Makes more accurate